### PR TITLE
Added conditionals to handle Ubuntu hosts

### DIFF
--- a/consul/dns_proxy.sls
+++ b/consul/dns_proxy.sls
@@ -16,6 +16,7 @@ configure_dnsmasq:
     - name: /etc/dnsmasq.d/10-consul
     - contents: 'server=/consul/127.0.0.1#{{ consul.dns_port }}'
 
+{% if not salt.cmd.run('which resolvconf') %}
 unset_immutable_bit_on_resolv_conf:
   cmd.run:
     - name: chattr -i /etc/resolv.conf
@@ -30,6 +31,7 @@ configure_resolv_conf:
     - name: chattr +i /etc/resolv.conf
     - require:
         - file: configure_resolv_conf
+{% endif %}
 
 dnsmasq_service_running:
   service.running:

--- a/consul/templates/consul.upstart
+++ b/consul/templates/consul.upstart
@@ -15,7 +15,4 @@ console log # log stdout/stderr to /var/log/upstart/
 export GOMAXPROCS=`nproc`
 
 
-exec /usr/bin/consul agent \
-  "-config-dir={{ consul.config_dir }} -data-dir={{ consul.data_dir }}" \
-  ${CONSUL_FLAGS} \
-  >> /var/log/consul.log 2>&1
+exec /usr/bin/consul agent -config-dir={{ consul.config_dir }} -data-dir={{ consul.data_dir }} ${CONSUL_FLAGS} >> /var/log/consul.log 2>&1


### PR DESCRIPTION
**Added conditionals to handle Ubuntu hosts**
Ubuntu hosts (at least 12.04) ship with resolvconf which handles
resolv.conf and automatically points to a local nameserver, which
dnsmasq will handle. In this case it's not necessary for salt to modify
the resolv.conf file
