### PR TITLE
Added check to install curl

### DIFF
--- a/consul/tests/init.sls
+++ b/consul/tests/init.sls
@@ -1,3 +1,8 @@
+install_curl:
+  pkg.installed:
+    - pkgs: curl
+    - pkg_verify: True
+
 install_pip_executable:
   cmd.run:
     - name: |


### PR DESCRIPTION
Consul tests can fail because they rely on curl to download the testinfra module which is not always installed. Added a check to install/verify that curl is there.