### PR TITLE
Fixing failure in name resolution

### DIFF
--- a/consul/install.sls
+++ b/consul/install.sls
@@ -20,6 +20,7 @@ install_consul_binary:
     - name: /usr/local/bin/
     - source: https://releases.hashicorp.com/consul/{{ consul.version }}/consul_{{ consul.version }}_linux_{{ consul.architecture_dict[grains['osarch']] }}.zip
     - source_hash: https://releases.hashicorp.com/consul/{{ consul.version }}/consul_{{ consul.version }}_SHA256SUMS
+    - source_hash_name: ./{{ consul.version }}/consul_{{ consul.version }}_linux_amd64.zip
     - archive_format: zip
     - if_missing: /usr/local/bin/consul
     - enforce_toplevel: False


### PR DESCRIPTION
`consul.update` fails with the following error:

`ID: install_consul_binary
    Function: archive.extracted
        Name: /usr/local/bin/
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python3/dist-packages/salt/state.py", line 1933, in call
                  **cdata['kwargs'])
                File "/usr/lib/python3/dist-packages/salt/loader.py", line 1951, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python3/dist-packages/salt/states/archive.py", line 930, in extracted
                  saltenv=__env__)
                File "/usr/lib/python3/dist-packages/salt/modules/file.py", line 831, in get_source_sum
                  hash_fn = __salt__['cp.cache_file'](source_hash, saltenv)
                File "/usr/lib/python3/dist-packages/salt/modules/cp.py", line 515, in cache_file
                  result = _client().cache_file(path, saltenv, source_hash=source_hash)
                File "/usr/lib/python3/dist-packages/salt/fileclient.py", line 193, in cache_file
                  path, '', True, saltenv, cachedir=cachedir, source_hash=source_hash)
                File "/usr/lib/python3/dist-packages/salt/fileclient.py", line 697, in get_url
                  raise MinionError('Error: {0} reading {1}'.format(query['error'], url))
              salt.exceptions.MinionError: Error: [Errno -3] Temporary failure in name resolution reading https://releases.hashicorp.com/consul/1.6.2/consul_1.6.2_SHA256SUMS`

Looking at the [docs](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.archive.html), it appears that adding the `source_hash_name` should solve the issue.

